### PR TITLE
Classe que nao e interface nao usa "I" na frente.

### DIFF
--- a/BLL/OperacoesBLL.cs
+++ b/BLL/OperacoesBLL.cs
@@ -4,7 +4,7 @@ using PrimeiraAPI.Models;
 
 namespace PrimeiraAPI.BLL
 {
-    public class _IOperacoesBLL : IOperacoesBLL
+    public class OperacoesBLL : IOperacoesBLL
     {
         public float SOMA(float num1, float num2)
         {

--- a/Startup.cs
+++ b/Startup.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using PrimeiraAPI.BLL;
+using PrimeiraAPI.BLL.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,6 +34,7 @@ namespace APIOPERACOES
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "APIOPERACOES", Version = "v1" });
             });
+            services.AddScoped<IOperacoesBLL, OperacoesBLL>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Quando se cria uma interface precisa configurar ela no startup.